### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: build
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -26,6 +26,8 @@ jobs:
   package:
     name: Build NuGet Package
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4.2.2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: publish
+permissions:
+  contents: read
 on:
     workflow_dispatch:
       inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/NF-Software-Inc/easy-blazor-bulma/security/code-scanning/3](https://github.com/NF-Software-Inc/easy-blazor-bulma/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for all jobs. Since the `prepare` job does not require write permissions, we will set `contents: read` as the default. This ensures that the workflow adheres to the principle of least privilege while maintaining functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
